### PR TITLE
Add CI checks for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Create Python virtual environment
+        run: |
+          python -m venv .venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
       - name: Install Python dependencies
         run: |
           make setup-maturin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Install Python dependencies
+        run: |
+          make setup-maturin
+          make setup-py
+      - name: Lint
+        run: make lint-all
+      - name: Test
+        run: make test-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
       - name: Create Python virtual environment
         run: |
           python -m venv .venv
@@ -32,6 +34,8 @@ jobs:
         run: |
           make setup-maturin
           make setup-py
+      - name: Format Rust
+        run: cargo fmt --all -- --check
       - name: Lint
         run: make lint-all
       - name: Test

--- a/crates/sorter-core/src/lib.rs
+++ b/crates/sorter-core/src/lib.rs
@@ -207,7 +207,7 @@ pub async fn compact_with_sort(table_uri: &str, cfg: SortConfig) -> Result<()> {
         let mut partitions_processed: usize = 0;
 
         use futures::stream;
-        let results: Vec<Result<PartitionMetrics>> = stream::iter(plan.groups.into_iter())
+        let results: Vec<Result<PartitionMetrics>> = stream::iter(plan.groups)
             .map(|g| {
                 let table_uri = table_uri.to_string();
                 let cfg = cfg.clone();
@@ -310,7 +310,7 @@ pub(crate) async fn plan_rewrites(table_uri: &str, cfg: &SortConfig) -> Result<R
         }
     }
 
-    groups.sort_by(|a, b| b.estimated_bytes.cmp(&a.estimated_bytes));
+    groups.sort_by_key(|group| std::cmp::Reverse(group.estimated_bytes));
 
     Ok(RewritePlan {
         table_uri: table_uri.to_string(),
@@ -646,14 +646,14 @@ async fn minmax_for_uri(
                     }
                 }
             }
-            if let Some(ref prev) = previous_tuple {
-                if cmp_tuple_with_nulls(prev, &t, nulls_first).is_gt() {
-                    // The min and max will be wrong, but since it's not sorted
-                    // that's irrelevant, we won't be using them.
-                    assert!(min_tuple.is_some() && max_tuple.is_some());
-                    is_ascending = false;
-                    break;
-                }
+            if let Some(ref prev) = previous_tuple
+                && cmp_tuple_with_nulls(prev, &t, nulls_first).is_gt()
+            {
+                // The min and max will be wrong, but since it's not sorted
+                // that's irrelevant, we won't be using them.
+                assert!(min_tuple.is_some() && max_tuple.is_some());
+                is_ascending = false;
+                break;
             }
             previous_tuple = Some(t.clone());
         }


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow for pushes to `main` and pull requests
- install the Python and Rust tooling required by the existing Makefile targets
- create an explicit Python virtual environment before the native development install
- clear the baseline Clippy warnings surfaced by the new strict lint gate so CI starts green
- run `make lint-all` and `make test-all` on Ubuntu
- keep the workflow token read-only

Fixes #2.

## Remote Linux validation

- `git diff --check origin/main...HEAD`
- `python -m venv .venv`
- `make setup-maturin`
- `make setup-py`
- `make lint-all`
- `make test-all`